### PR TITLE
fix/justify-text-spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -659,6 +659,8 @@ header h1 {
     line-height: 1.7;
     font-size: 1.05rem;
     text-align: justify;
+    -webkit-hyphens: auto;
+    hyphens: auto;
 }
 
 /* Card Flip Animation */


### PR DESCRIPTION
from [Excessive Word Spacing in card summary text](https://github.com/patcharapon-j/Storypath-System/issues/1) 
Add CSS to summary-card p
```
-webkit-hyphens: auto;
hyphens: auto;
```
![image_before_after](https://i.imgur.com/g9SKM4D.png)